### PR TITLE
Use "typescript" as devDependency instead of plain dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,13 +37,13 @@
     "@types/node": "^12.11.1",
     "@types/source-map-support": "^0.5.0",
     "browserify": "^16.5.0",
-    "jest": "^24.9.0"
+    "jest": "^24.9.0",
+    "typescript": "^3.6.4"
   },
   "dependencies": {
     "lodash.clonedeep": "^4.5.0",
     "lodash.escaperegexp": "^4.1.2",
     "pirates": "^4.0.1",
-    "source-map-support": "^0.5.13",
-    "typescript": "^3.6.4"
+    "source-map-support": "^0.5.13"
   }
 }


### PR DESCRIPTION
Since the "typescript" dependency won't be used at run-time.