### PR TITLE
Fix: swc-node

### DIFF
--- a/bin/swc-node
+++ b/bin/swc-node
@@ -11,7 +11,7 @@ const {resolve} = require("path");
  * `node -r @swc/register` or register a require hook programmatically from
  * your own code.
  */
-require("..");
+require("..")();
 
 process.argv.splice(1, 1);
 process.argv[1] = resolve(process.argv[1]);


### PR DESCRIPTION
If swc doesn't want a dedicated `@swc/node` package, a simple change could be introduced to prevent breaking changes introduced in #14.