### PR TITLE
Fix `node --require @swc/register`

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,7 @@ exports = module.exports = function(...args: InputOptions[]) {
 };
 exports.__esModule = true;
 
-const node = require("./node");
+const node = require("./nodeWrapper");
 const register = node.default;
 
 Object.assign(exports, node);

--- a/src/nodeWrapper.ts
+++ b/src/nodeWrapper.ts
@@ -1,0 +1,5 @@
+import register from "./node";
+
+register();
+
+export default register;


### PR DESCRIPTION
Loading `@swc/register` was broken because it did not automatically call `register()`.

This commit fixes that issue by using `@babel/register`'s approach of using an intermediate module named `nodeWrapper.ts` to call `register()`. The wrapper module lets library authors import `node.ts` without automatically invoking `register()`.

Tested by making sure the unit tests pass with `npm test`. Tested that registration works again by running `node -r /path/to/swc/register my-test-file.ts` and seeing that TS code was compiled on the fly.

Fixes #17