### PR TITLE
Add GitHub Action workflow to run tests on each PR and commit

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Tests
+on: push
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: lts
+      - name: Cache npm packages
+        uses: actions/cache@v2
+        with:
+          path: ${{ github.workspace }}/node_modules
+          key: ${{ runner.OS }}-node_modules-${{ hashFiles('package.json') }}
+      - run: npm install
+      - run: npm test


### PR DESCRIPTION
This is a small workflow to run automated tests so that it is possible to see from the PR page whether tests are passing or not.

There is a node_modules cache that is invalidated whenever package.json changes. It would be better to use package-lock.json or better yet npm-shrinkwrap.json but that is out of scope.