### PR TITLE
Fix the Node version specifier for GitHub Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: push
+on: [push, pull_request]
 jobs:
   test:
     name: Test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2
         with:
-          node-version: lts
+          node-version: lts/*
       - name: Cache npm packages
         uses: actions/cache@v2
         with:


### PR DESCRIPTION
`actions/setup-node@v2` does not accept "lts" as a version. It requires "lts/*".

Additionally, this PR adds "pull_request" to the list of GitHub Actions triggers so that tests run on each PR, as shown below.

Test plan: make sure the tests for this PR succeed.